### PR TITLE
feat: add emergency stop feature with double-Escape hotkey

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,7 +316,7 @@ This focuses coverage metrics on actual business logic rather than framework cod
 ### Current Limitations
 - Text-only clipboard support (no images, files, etc.)
 - No clipboard monitoring or history
-- No global hotkeys
+- No global hotkeys (except for emergency stop)
 - No settings window (configuration via tray menu only)
 - No automatic update mechanism
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ cargo tauri build
 2. Copy text normally (Ctrl+C/Cmd+C)
 3. Click "Paste" in tray menu to type it out
 
+### Emergency Stop
+
+Press **Escape twice** quickly (within 500ms) to instantly cancel any ongoing typing operation. You can also click "Cancel Typing (Esc Esc)" in the tray menu.
+
 Adjust typing speed and left-click behavior from the tray menu.
 
 ## Configuration

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1335,6 +1335,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "global-hotkey"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9247516746aa8e53411a0db9b62b0e24efbcf6a76e0ba73e5a91b512ddabed7"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2 0.6.1",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.12",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2486,6 +2504,7 @@ dependencies = [
  "serial_test",
  "tauri",
  "tauri-build",
+ "tauri-plugin-global-shortcut",
  "tempfile",
  "tokio",
  "toml",
@@ -3738,6 +3757,38 @@ dependencies = [
  "syn 2.0.104",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37a5ebe6a610d1b78a94650896e6f7c9796323f408800cef436e0fa0539de601"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "toml",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31919f3c07bcb585afef217c0c33cde80da9ebccf5b8e2c90e0e0a535b14ab47"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,9 @@ mockall = "0.13"
 tempfile = "3.8"
 serial_test = "3.0"
 
+[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+tauri-plugin-global-shortcut = "2"
+
 [package.metadata.bundle]
 identifier = "com.pasta.app"
 icon = ["icons/icon.icns", "icons/icon.ico", "icons/icon.png"]

--- a/src-tauri/capabilities/desktop.json
+++ b/src-tauri/capabilities/desktop.json
@@ -1,0 +1,14 @@
+{
+  "identifier": "desktop-capability",
+  "platforms": [
+    "macOS",
+    "windows",
+    "linux"
+  ],
+  "windows": [
+    "main"
+  ],
+  "permissions": [
+    "global-shortcut:default"
+  ]
+}

--- a/src-tauri/src/additional_tests.rs
+++ b/src-tauri/src/additional_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod additional_coverage_tests {
-    use std::sync::{Arc, Mutex};
+    use std::sync::{atomic::AtomicBool, Arc, Mutex};
 
     use tempfile::TempDir;
 
@@ -17,6 +17,7 @@ mod additional_coverage_tests {
         let keyboard_emulator = Arc::new(KeyboardEmulator::new().unwrap());
         let app_state = AppState {
             keyboard_emulator: keyboard_emulator.clone(),
+            is_typing_cancelled: Arc::new(AtomicBool::new(false)),
         };
 
         // Test multiple clones

--- a/src-tauri/src/app_logic.rs
+++ b/src-tauri/src/app_logic.rs
@@ -1,7 +1,4 @@
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
+use std::sync::{atomic::AtomicBool, Arc};
 
 use crate::keyboard::{KeyboardEmulator, TypingSpeed};
 
@@ -150,7 +147,7 @@ pub fn handle_menu_event(event_id: &str) -> MenuAction {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex;
+    use std::sync::{atomic::Ordering, Mutex};
 
     use super::*;
     use crate::keyboard::KeyboardEmulator;
@@ -182,7 +179,8 @@ mod tests {
         let keyboard_emulator = Arc::new(KeyboardEmulator::new().unwrap());
         let cancellation_flag = Arc::new(AtomicBool::new(false));
 
-        let result = handle_paste_clipboard(&clipboard, &keyboard_emulator, cancellation_flag).await;
+        let result =
+            handle_paste_clipboard(&clipboard, &keyboard_emulator, cancellation_flag).await;
         assert!(result.is_ok());
     }
 
@@ -194,7 +192,8 @@ mod tests {
         let keyboard_emulator = Arc::new(KeyboardEmulator::new().unwrap());
         let cancellation_flag = Arc::new(AtomicBool::new(false));
 
-        let result = handle_paste_clipboard(&clipboard, &keyboard_emulator, cancellation_flag).await;
+        let result =
+            handle_paste_clipboard(&clipboard, &keyboard_emulator, cancellation_flag).await;
         assert!(result.is_ok());
     }
 
@@ -214,7 +213,8 @@ mod tests {
         let keyboard_emulator = Arc::new(KeyboardEmulator::new().unwrap());
         let cancellation_flag = Arc::new(AtomicBool::new(false));
 
-        let result = handle_paste_clipboard(&clipboard, &keyboard_emulator, cancellation_flag).await;
+        let result =
+            handle_paste_clipboard(&clipboard, &keyboard_emulator, cancellation_flag).await;
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), "Clipboard access denied");
     }
@@ -467,7 +467,8 @@ mod tests {
         };
         let cancellation_flag = Arc::new(AtomicBool::new(false));
 
-        let result = handle_paste_clipboard(&clipboard, &keyboard_emulator, cancellation_flag).await;
+        let result =
+            handle_paste_clipboard(&clipboard, &keyboard_emulator, cancellation_flag).await;
         assert!(result.is_ok());
     }
 
@@ -477,14 +478,15 @@ mod tests {
     async fn test_handle_paste_clipboard_with_cancellation() {
         let clipboard = MockClipboard::new(Some("test text".to_string()));
         let cancellation_flag = Arc::new(AtomicBool::new(false));
-        
+
         // Create a real keyboard emulator
         let keyboard_emulator = Arc::new(crate::keyboard::KeyboardEmulator::new().unwrap());
 
         // Set cancellation flag before calling
         cancellation_flag.store(true, Ordering::Relaxed);
 
-        let result = handle_paste_clipboard(&clipboard, &keyboard_emulator, cancellation_flag).await;
+        let result =
+            handle_paste_clipboard(&clipboard, &keyboard_emulator, cancellation_flag).await;
         assert!(result.is_ok()); // The function should still return Ok even if cancelled
     }
 

--- a/src-tauri/src/app_logic_comprehensive_tests.rs
+++ b/src-tauri/src/app_logic_comprehensive_tests.rs
@@ -1,7 +1,6 @@
 #[cfg(test)]
 mod app_logic_comprehensive_tests {
-    use std::sync::{Arc, Mutex};
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{atomic::AtomicBool, Arc, Mutex};
 
     use crate::{
         app_logic::{
@@ -51,24 +50,28 @@ mod app_logic_comprehensive_tests {
 
         // Test empty clipboard
         let empty_clipboard = MockClipboard::new(Ok(None));
-        let result = handle_paste_clipboard(&empty_clipboard, &keyboard, cancellation_flag.clone()).await;
+        let result =
+            handle_paste_clipboard(&empty_clipboard, &keyboard, cancellation_flag.clone()).await;
         assert!(result.is_ok()); // Empty clipboard now returns Ok
 
         // Test clipboard error
         let error_clipboard = MockClipboard::new(Err("Access denied".to_string()));
-        let result = handle_paste_clipboard(&error_clipboard, &keyboard, cancellation_flag.clone()).await;
+        let result =
+            handle_paste_clipboard(&error_clipboard, &keyboard, cancellation_flag.clone()).await;
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), "Access denied");
 
         // Test very long content
         let long_content = "x".repeat(10000);
         let long_clipboard = MockClipboard::new(Ok(Some(long_content)));
-        let result = handle_paste_clipboard(&long_clipboard, &keyboard, cancellation_flag.clone()).await;
+        let result =
+            handle_paste_clipboard(&long_clipboard, &keyboard, cancellation_flag.clone()).await;
         assert!(result.is_ok());
 
         // Test unicode content
         let unicode_clipboard = MockClipboard::new(Ok(Some("Hello 世界 🦀".to_string())));
-        let result = handle_paste_clipboard(&unicode_clipboard, &keyboard, cancellation_flag.clone()).await;
+        let result =
+            handle_paste_clipboard(&unicode_clipboard, &keyboard, cancellation_flag.clone()).await;
         assert!(result.is_ok());
 
         // Test content with special characters
@@ -99,11 +102,20 @@ mod app_logic_comprehensive_tests {
                     _ => panic!("Expected Action item"),
                 }
 
+                // Verify cancel typing item
+                match &menu_structure.items[1] {
+                    MenuItem::Action { id, label } => {
+                        assert_eq!(id, "cancel_typing");
+                        assert_eq!(label, "Cancel Typing (Esc Esc)");
+                    }
+                    _ => panic!("Expected Action item"),
+                }
+
                 // Verify separator
-                assert!(matches!(menu_structure.items[1], MenuItem::Separator));
+                assert!(matches!(menu_structure.items[2], MenuItem::Separator));
 
                 // Verify typing speed submenu
-                match &menu_structure.items[2] {
+                match &menu_structure.items[3] {
                     MenuItem::Submenu { label, .. } => {
                         assert_eq!(label, "Typing Speed");
                     }
@@ -111,7 +123,7 @@ mod app_logic_comprehensive_tests {
                 }
 
                 // Check submenu items
-                if let MenuItem::Submenu { items, .. } = &menu_structure.items[2] {
+                if let MenuItem::Submenu { items, .. } = &menu_structure.items[3] {
                     assert_eq!(items.len(), 3);
 
                     // Check which speed is selected
@@ -128,7 +140,7 @@ mod app_logic_comprehensive_tests {
                 }
 
                 // Verify left click paste item
-                match &menu_structure.items[3] {
+                match &menu_structure.items[4] {
                     MenuItem::CheckItem { id, label, checked } => {
                         assert_eq!(id, "left_click_paste");
                         assert_eq!(label, "Left Click Pastes");
@@ -138,10 +150,10 @@ mod app_logic_comprehensive_tests {
                 }
 
                 // Verify separator
-                assert!(matches!(menu_structure.items[4], MenuItem::Separator));
+                assert!(matches!(menu_structure.items[5], MenuItem::Separator));
 
                 // Verify quit item
-                match &menu_structure.items[5] {
+                match &menu_structure.items[6] {
                     MenuItem::Action { id, label } => {
                         assert_eq!(id, "quit");
                         assert_eq!(label, "Quit");
@@ -295,10 +307,10 @@ mod app_logic_comprehensive_tests {
 
         for (speed, left_click) in states {
             let menu = create_menu_structure(speed, left_click);
-            assert_eq!(menu.items.len(), 6); // paste, sep, speed, left_click, sep, quit
+            assert_eq!(menu.items.len(), 7); // paste, cancel_typing, sep, speed, left_click, sep, quit
 
             // Verify correct speed is selected
-            if let MenuItem::Submenu { items, .. } = &menu.items[2] {
+            if let MenuItem::Submenu { items, .. } = &menu.items[3] {
                 let checked_count = items
                     .iter()
                     .filter(|item| {

--- a/src-tauri/src/comprehensive_tests.rs
+++ b/src-tauri/src/comprehensive_tests.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod comprehensive_integration_tests {
+    use std::sync::{atomic::AtomicBool, Arc};
 
     use crate::{
         app_logic::{create_menu_structure, handle_menu_event, MenuAction, MenuItem},
@@ -36,7 +37,7 @@ mod comprehensive_integration_tests {
 
         // 5. Test menu structure creation
         let menu_structure = create_menu_structure(config.typing_speed, config.left_click_paste);
-        assert_eq!(menu_structure.items.len(), 6); // Expected number of menu items
+        assert_eq!(menu_structure.items.len(), 7); // Expected number of menu items
 
         // 6. Test menu event handling
         let paste_action = handle_menu_event("paste");
@@ -51,7 +52,7 @@ mod comprehensive_integration_tests {
         assert_eq!(tray_action, TrayIconAction::PasteClipboard);
 
         // 8. Test paste event handling
-        handle_paste_clipboard_event(keyboard_emulator.clone());
+        handle_paste_clipboard_event(keyboard_emulator.clone(), Arc::new(AtomicBool::new(false)));
     }
 
     #[test]
@@ -160,7 +161,7 @@ mod comprehensive_integration_tests {
             let ke = keyboard_emulator.clone();
             handles.push(thread::spawn(move || {
                 for _ in 0..10 {
-                    handle_paste_clipboard_event(ke.clone());
+                    handle_paste_clipboard_event(ke.clone(), Arc::new(AtomicBool::new(false)));
                     thread::sleep(Duration::from_millis(5));
                 }
             }));

--- a/src-tauri/src/error_tests.rs
+++ b/src-tauri/src/error_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod error_scenario_tests {
-    use std::sync::Arc;
+    use std::sync::{atomic::AtomicBool, Arc};
 
     use tempfile::TempDir;
 
@@ -34,7 +34,12 @@ mod error_scenario_tests {
         let clipboard = FailingClipboard;
         let keyboard_emulator = Arc::new(KeyboardEmulator::new().unwrap());
 
-        let result = handle_paste_clipboard(&clipboard, &keyboard_emulator).await;
+        let result = handle_paste_clipboard(
+            &clipboard,
+            &keyboard_emulator,
+            Arc::new(AtomicBool::new(false)),
+        )
+        .await;
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), "Simulated clipboard failure");
     }
@@ -45,7 +50,12 @@ mod error_scenario_tests {
         let clipboard = EmptyClipboard;
         let keyboard_emulator = Arc::new(KeyboardEmulator::new().unwrap());
 
-        let result = handle_paste_clipboard(&clipboard, &keyboard_emulator).await;
+        let result = handle_paste_clipboard(
+            &clipboard,
+            &keyboard_emulator,
+            Arc::new(AtomicBool::new(false)),
+        )
+        .await;
         assert!(result.is_ok());
     }
 
@@ -157,7 +167,9 @@ typing_speed = "INVALID_SPEED"
         ];
 
         for text in special_texts {
-            let result = keyboard_emulator.type_text(text).await;
+            let result = keyboard_emulator
+                .type_text(text, Arc::new(AtomicBool::new(false)))
+                .await;
             assert!(result.is_ok());
         }
     }

--- a/src-tauri/src/hotkey.rs
+++ b/src-tauri/src/hotkey.rs
@@ -20,7 +20,12 @@ impl HotkeyManager {
     pub fn new() -> Self {
         Self {
             last_escape_time: Arc::new(AtomicU64::new(0)),
-            double_press_window_ms: 500, // 500ms window for double-press
+            // 500ms window for double-press detection
+            // This timing was chosen to balance between:
+            // - Being quick enough to not interfere with normal Escape usage
+            // - Being long enough to reliably detect intentional double-presses
+            // - Matching common double-click timing expectations (400-600ms)
+            double_press_window_ms: 500,
         }
     }
 

--- a/src-tauri/src/hotkey.rs
+++ b/src-tauri/src/hotkey.rs
@@ -1,0 +1,189 @@
+use std::sync::{
+    atomic::{AtomicBool, AtomicU64, Ordering},
+    Arc,
+};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use log::{debug, info};
+use tauri::{AppHandle, Emitter, Manager};
+use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut};
+
+/// Manages global hotkeys for the application
+pub struct HotkeyManager {
+    last_escape_time: Arc<AtomicU64>,
+    double_press_window_ms: u64,
+}
+
+impl HotkeyManager {
+    pub fn new() -> Self {
+        Self {
+            last_escape_time: Arc::new(AtomicU64::new(0)),
+            double_press_window_ms: 500, // 500ms window for double-press
+        }
+    }
+
+    /// Register the global hotkeys
+    pub fn register_hotkeys<R: tauri::Runtime>(
+        &self,
+        app_handle: &AppHandle<R>,
+        cancellation_flag: Arc<AtomicBool>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let escape_shortcut = Shortcut::new(None, Code::Escape);
+        let last_escape_time = self.last_escape_time.clone();
+        let double_press_window = self.double_press_window_ms;
+
+        app_handle.global_shortcut().on_shortcut(
+            escape_shortcut,
+            move |app_handle, _shortcut, _event| {
+                let current_time = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis() as u64;
+
+                let last_time = last_escape_time.load(Ordering::Relaxed);
+                let time_diff = current_time.saturating_sub(last_time);
+
+                debug!("Escape pressed. Time since last: {}ms", time_diff);
+
+                if time_diff <= double_press_window {
+                    // Double-press detected
+                    info!("Double-Escape detected! Cancelling typing operation");
+                    cancellation_flag.store(true, Ordering::Relaxed);
+                    last_escape_time.store(0, Ordering::Relaxed); // Reset to prevent triple-press
+                    
+                    // Optional: Emit an event for UI feedback
+                    let _ = app_handle.emit("typing_cancelled", ());
+                } else {
+                    // First press or too much time has passed
+                    last_escape_time.store(current_time, Ordering::Relaxed);
+                }
+            },
+        )?;
+
+        info!("Registered double-Escape hotkey for emergency stop");
+        Ok(())
+    }
+
+    /// Alternative: Register Ctrl+Shift+Escape for simpler implementation
+    pub fn register_ctrl_shift_escape<R: tauri::Runtime>(
+        &self,
+        app_handle: &AppHandle<R>,
+        cancellation_flag: Arc<AtomicBool>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let shortcut = Shortcut::new(
+            Some(Modifiers::CONTROL | Modifiers::SHIFT),
+            Code::Escape,
+        );
+
+        app_handle.global_shortcut().on_shortcut(
+            shortcut,
+            move |app_handle, _shortcut, _event| {
+                info!("Ctrl+Shift+Escape pressed! Cancelling typing operation");
+                cancellation_flag.store(true, Ordering::Relaxed);
+                
+                // Optional: Emit an event for UI feedback
+                let _ = app_handle.emit("typing_cancelled", ());
+            },
+        )?;
+
+        info!("Registered Ctrl+Shift+Escape hotkey for emergency stop");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hotkey_manager_creation() {
+        let manager = HotkeyManager::new();
+        assert_eq!(manager.double_press_window_ms, 500);
+        assert_eq!(manager.last_escape_time.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn test_time_difference_calculation() {
+        let current_time = 1000u64;
+        let last_time = 600u64;
+        let diff = current_time.saturating_sub(last_time);
+        assert_eq!(diff, 400);
+
+        // Test saturating subtraction
+        let current_time = 100u64;
+        let last_time = 200u64;
+        let diff = current_time.saturating_sub(last_time);
+        assert_eq!(diff, 0);
+    }
+
+    #[test]
+    fn test_double_press_detection_logic() {
+        let double_press_window = 500u64;
+
+        // Within window
+        let time_diff = 300u64;
+        assert!(time_diff <= double_press_window);
+
+        // Exactly at window boundary
+        let time_diff = 500u64;
+        assert!(time_diff <= double_press_window);
+
+        // Outside window
+        let time_diff = 501u64;
+        assert!(!(time_diff <= double_press_window));
+    }
+
+    #[test]
+    fn test_atomic_operations() {
+        let atomic_time = Arc::new(AtomicU64::new(0));
+        
+        // Test store and load
+        atomic_time.store(1000, Ordering::Relaxed);
+        assert_eq!(atomic_time.load(Ordering::Relaxed), 1000);
+
+        // Test with clone
+        let cloned = atomic_time.clone();
+        cloned.store(2000, Ordering::Relaxed);
+        assert_eq!(atomic_time.load(Ordering::Relaxed), 2000);
+    }
+
+    #[test]
+    fn test_cancellation_flag_operations() {
+        let flag = Arc::new(AtomicBool::new(false));
+        
+        // Test initial state
+        assert!(!flag.load(Ordering::Relaxed));
+
+        // Test setting to true
+        flag.store(true, Ordering::Relaxed);
+        assert!(flag.load(Ordering::Relaxed));
+
+        // Test resetting
+        flag.store(false, Ordering::Relaxed);
+        assert!(!flag.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn test_system_time_conversion() {
+        let time = SystemTime::now();
+        let duration = time.duration_since(UNIX_EPOCH).unwrap();
+        let millis = duration.as_millis() as u64;
+        
+        assert!(millis > 0);
+        assert!(millis < u64::MAX);
+    }
+
+    #[test]
+    fn test_shortcut_creation() {
+        // Test escape without modifiers
+        let escape_shortcut = Shortcut::new(None, Code::Escape);
+        assert!(matches!(escape_shortcut.key, Code::Escape));
+
+        // Test ctrl+shift+escape
+        let ctrl_shift_escape = Shortcut::new(
+            Some(Modifiers::CONTROL | Modifiers::SHIFT),
+            Code::Escape,
+        );
+        assert!(matches!(ctrl_shift_escape.key, Code::Escape));
+    }
+}

--- a/src-tauri/src/init_tests.rs
+++ b/src-tauri/src/init_tests.rs
@@ -2,7 +2,7 @@
 mod init_tests {
     use std::{
         path::PathBuf,
-        sync::{Arc, Mutex},
+        sync::{atomic::AtomicBool, Arc, Mutex},
     };
 
     use tempfile::TempDir;
@@ -98,7 +98,10 @@ mod init_tests {
 
         // Call handle_paste_clipboard_event multiple times
         for _ in 0..3 {
-            handle_paste_clipboard_event(keyboard_emulator.clone());
+            handle_paste_clipboard_event(
+                keyboard_emulator.clone(),
+                Arc::new(AtomicBool::new(false)),
+            );
             // Give thread time to start
             std::thread::sleep(std::time::Duration::from_millis(5));
         }

--- a/src-tauri/src/integration_test_emergency_stop.rs
+++ b/src-tauri/src/integration_test_emergency_stop.rs
@@ -1,0 +1,158 @@
+#[cfg(test)]
+mod integration_tests {
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+    use std::time::Duration;
+
+    use crate::{
+        app_logic::{handle_paste_clipboard, ClipboardProvider},
+        keyboard::KeyboardEmulator,
+    };
+
+    /// Mock clipboard that returns a long text string
+    struct LongTextClipboard {
+        text: String,
+    }
+
+    impl LongTextClipboard {
+        fn new(length: usize) -> Self {
+            Self {
+                text: "a".repeat(length),
+            }
+        }
+    }
+
+    impl ClipboardProvider for LongTextClipboard {
+        fn get_content(&self) -> Result<Option<String>, String> {
+            Ok(Some(self.text.clone()))
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "Creates real keyboard emulator that can type on system - run with --ignored flag"]
+    async fn test_emergency_stop_cancels_typing() {
+        // Create a mock keyboard emulator that simulates typing
+        let keyboard_emulator = Arc::new(KeyboardEmulator::new().unwrap());
+        let cancellation_flag = Arc::new(AtomicBool::new(false));
+        let clipboard = LongTextClipboard::new(1000); // Long text to type
+
+        // Clone for the cancellation thread
+        let cancellation_flag_clone = cancellation_flag.clone();
+
+        // Start typing in a task
+        let typing_task = tokio::spawn(async move {
+            handle_paste_clipboard(&clipboard, &keyboard_emulator, cancellation_flag_clone).await
+        });
+
+        // Wait a bit for typing to start
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Trigger cancellation (simulating double-Escape press)
+        cancellation_flag.store(true, Ordering::Relaxed);
+
+        // Wait for the typing task to complete
+        let result = typing_task.await.unwrap();
+        assert!(result.is_ok());
+
+        // Verify that not all text was typed (since we cancelled)
+        // Note: In a real keyboard emulator, we would check that typing stopped
+        // For the mock, we just verify the function completed without error
+    }
+
+    #[tokio::test]
+    #[ignore = "Creates real keyboard emulator that can type on system - run with --ignored flag"]
+    async fn test_cancellation_flag_reset_before_new_operation() {
+        let keyboard_emulator = Arc::new(KeyboardEmulator::new().unwrap());
+        let clipboard = LongTextClipboard::new(100);
+
+        // First operation with cancellation
+        let cancellation_flag = Arc::new(AtomicBool::new(false));
+        cancellation_flag.store(true, Ordering::Relaxed); // Pre-cancelled
+
+        let result = handle_paste_clipboard(&clipboard, &keyboard_emulator, cancellation_flag.clone()).await;
+        assert!(result.is_ok());
+
+        // Reset flag for second operation
+        cancellation_flag.store(false, Ordering::Relaxed);
+
+        // Second operation should work normally
+        let result = handle_paste_clipboard(&clipboard, &keyboard_emulator, cancellation_flag).await;
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_cancellation_flag_thread_safety() {
+        let cancellation_flag = Arc::new(AtomicBool::new(false));
+        let mut handles = vec![];
+
+        // Spawn multiple threads that try to set the flag
+        for i in 0..10 {
+            let flag_clone = cancellation_flag.clone();
+            let handle = std::thread::spawn(move || {
+                std::thread::sleep(Duration::from_millis(i * 10));
+                flag_clone.store(true, Ordering::Relaxed);
+            });
+            handles.push(handle);
+        }
+
+        // Wait for all threads
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        // Flag should be true after all threads complete
+        assert!(cancellation_flag.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn test_double_escape_timing_window() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let double_press_window_ms = 500u64;
+        
+        // Simulate first press
+        let first_press = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+
+        // Test within window
+        let second_press_within = first_press + 300;
+        let diff_within = second_press_within.saturating_sub(first_press);
+        assert!(diff_within <= double_press_window_ms);
+
+        // Test outside window
+        let second_press_outside = first_press + 600;
+        let diff_outside = second_press_outside.saturating_sub(first_press);
+        assert!(diff_outside > double_press_window_ms);
+    }
+
+    #[tokio::test]
+    #[ignore = "Creates real keyboard emulator that can type on system - run with --ignored flag"]
+    async fn test_multiple_emergency_stops() {
+        let keyboard_emulator = Arc::new(KeyboardEmulator::new().unwrap());
+        let clipboard = LongTextClipboard::new(500);
+        
+        // Test multiple cancellations
+        for _ in 0..3 {
+            let cancellation_flag = Arc::new(AtomicBool::new(false));
+            
+            // Start typing
+            let flag_clone = cancellation_flag.clone();
+            let keyboard_clone = keyboard_emulator.clone();
+            let typing_task = tokio::spawn(async move {
+                handle_paste_clipboard(&clipboard, &keyboard_clone, flag_clone).await
+            });
+
+            // Cancel quickly
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            cancellation_flag.store(true, Ordering::Relaxed);
+
+            // Verify task completes
+            let result = typing_task.await.unwrap();
+            assert!(result.is_ok());
+        }
+    }
+}

--- a/src-tauri/src/integration_tests.rs
+++ b/src-tauri/src/integration_tests.rs
@@ -2,8 +2,7 @@
 mod integration_tests {
     use std::{
         path::PathBuf,
-        sync::{Arc, Mutex},
-        sync::atomic::{AtomicBool, Ordering},
+        sync::{atomic::AtomicBool, Arc, Mutex},
     };
 
     use tempfile::TempDir;
@@ -101,7 +100,8 @@ mod integration_tests {
 
         // Execute paste operation
         let cancellation_flag = Arc::new(AtomicBool::new(false));
-        let result = handle_paste_clipboard(&clipboard, &keyboard_emulator, cancellation_flag).await;
+        let result =
+            handle_paste_clipboard(&clipboard, &keyboard_emulator, cancellation_flag).await;
         assert!(result.is_ok());
     }
 
@@ -275,7 +275,9 @@ mod integration_tests {
         for content in test_contents {
             runtime.block_on(async {
                 let cancellation_flag = Arc::new(AtomicBool::new(false));
-                let result = keyboard_emulator.type_text(content, cancellation_flag).await;
+                let result = keyboard_emulator
+                    .type_text(content, cancellation_flag)
+                    .await;
                 assert!(result.is_ok());
             });
         }

--- a/src-tauri/src/integration_tests.rs
+++ b/src-tauri/src/integration_tests.rs
@@ -3,6 +3,7 @@ mod integration_tests {
     use std::{
         path::PathBuf,
         sync::{Arc, Mutex},
+        sync::atomic::{AtomicBool, Ordering},
     };
 
     use tempfile::TempDir;
@@ -99,7 +100,8 @@ mod integration_tests {
         let keyboard_emulator = Arc::new(KeyboardEmulator::new().unwrap());
 
         // Execute paste operation
-        let result = handle_paste_clipboard(&clipboard, &keyboard_emulator).await;
+        let cancellation_flag = Arc::new(AtomicBool::new(false));
+        let result = handle_paste_clipboard(&clipboard, &keyboard_emulator, cancellation_flag).await;
         assert!(result.is_ok());
     }
 
@@ -120,7 +122,8 @@ mod integration_tests {
         assert_eq!(config_manager.get().typing_speed, TypingSpeed::Fast);
 
         // Test paste event
-        handle_paste_clipboard_event(keyboard_emulator.clone());
+        let cancellation_flag = Arc::new(AtomicBool::new(false));
+        handle_paste_clipboard_event(keyboard_emulator.clone(), cancellation_flag);
 
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
@@ -149,7 +152,8 @@ mod integration_tests {
                         handle_config_changed(&cm, &ke);
                     } else {
                         // Paste operations
-                        handle_paste_clipboard_event(ke);
+                        let cancellation_flag = Arc::new(AtomicBool::new(false));
+                        handle_paste_clipboard_event(ke, cancellation_flag);
                     }
                 })
             })
@@ -270,7 +274,8 @@ mod integration_tests {
 
         for content in test_contents {
             runtime.block_on(async {
-                let result = keyboard_emulator.type_text(content).await;
+                let cancellation_flag = Arc::new(AtomicBool::new(false));
+                let result = keyboard_emulator.type_text(content, cancellation_flag).await;
                 assert!(result.is_ok());
             });
         }

--- a/src-tauri/src/keyboard.rs
+++ b/src-tauri/src/keyboard.rs
@@ -570,13 +570,15 @@ mod tests {
         let flag_clone = cancellation_flag.clone();
 
         // Simulate setting the flag in another thread
-        std::thread::spawn(move || {
+        let handle = std::thread::spawn(move || {
             std::thread::sleep(Duration::from_millis(10));
             flag_clone.store(true, Ordering::Relaxed);
         });
 
-        // Wait a bit and check the flag
-        std::thread::sleep(Duration::from_millis(20));
+        // Wait for the thread to complete
+        handle.join().unwrap();
+        
+        // Now check the flag - it should definitely be set
         assert!(cancellation_flag.load(Ordering::Relaxed));
     }
 

--- a/src-tauri/src/keyboard.rs
+++ b/src-tauri/src/keyboard.rs
@@ -577,7 +577,7 @@ mod tests {
 
         // Wait for the thread to complete
         handle.join().unwrap();
-        
+
         // Now check the flag - it should definitely be set
         assert!(cancellation_flag.load(Ordering::Relaxed));
     }

--- a/src-tauri/src/keyboard.rs
+++ b/src-tauri/src/keyboard.rs
@@ -71,6 +71,11 @@ impl KeyboardEmulator {
 
                             // Type each character in the chunk
                             for (char_index, ch) in chunk.chars().enumerate() {
+                                // Check cancellation at the start of each character for immediate response
+                                if char_index == 0 && cancellation_flag.load(Ordering::Relaxed) {
+                                    info!("Typing cancelled by user");
+                                    break;
+                                }
                                 // Check cancellation flag periodically (every 10 characters)
                                 if char_index % 10 == 0 && cancellation_flag.load(Ordering::Relaxed)
                                 {

--- a/src-tauri/src/keyboard_execution_tests.rs
+++ b/src-tauri/src/keyboard_execution_tests.rs
@@ -1,10 +1,7 @@
 #[cfg(test)]
 mod keyboard_execution_tests {
     use std::{
-        sync::{
-            atomic::{AtomicBool, Ordering},
-            Arc,
-        },
+        sync::{atomic::AtomicBool, Arc},
         time::Duration,
     };
 

--- a/src-tauri/src/keyboard_execution_tests.rs
+++ b/src-tauri/src/keyboard_execution_tests.rs
@@ -1,7 +1,12 @@
 #[cfg(test)]
 mod keyboard_execution_tests {
-    use std::{sync::Arc, time::Duration};
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        time::Duration,
+    };
 
     use tokio::sync::mpsc;
 
@@ -70,9 +75,12 @@ mod keyboard_execution_tests {
                 .await
                 .unwrap();
             let cancellation_flag = Arc::new(AtomicBool::new(false));
-            tx.send(KeyboardCommand::TypeText("Hello".to_string(), cancellation_flag))
-                .await
-                .unwrap();
+            tx.send(KeyboardCommand::TypeText(
+                "Hello".to_string(),
+                cancellation_flag,
+            ))
+            .await
+            .unwrap();
         });
 
         // Give thread time to process
@@ -187,24 +195,36 @@ mod keyboard_execution_tests {
         let runtime = tokio::runtime::Runtime::new().unwrap();
         runtime.block_on(async {
             let cancellation_flag = Arc::new(AtomicBool::new(false));
-            
+
             // Fill the channel
-            tx.send(KeyboardCommand::TypeText("1".to_string(), cancellation_flag.clone()))
-                .await
-                .unwrap();
-            tx.send(KeyboardCommand::TypeText("2".to_string(), cancellation_flag.clone()))
-                .await
-                .unwrap();
+            tx.send(KeyboardCommand::TypeText(
+                "1".to_string(),
+                cancellation_flag.clone(),
+            ))
+            .await
+            .unwrap();
+            tx.send(KeyboardCommand::TypeText(
+                "2".to_string(),
+                cancellation_flag.clone(),
+            ))
+            .await
+            .unwrap();
 
             // This would block if channel is full, so try_send
-            let result = tx.try_send(KeyboardCommand::TypeText("3".to_string(), cancellation_flag.clone()));
+            let result = tx.try_send(KeyboardCommand::TypeText(
+                "3".to_string(),
+                cancellation_flag.clone(),
+            ));
             assert!(result.is_err()); // Channel should be full
 
             // Consume one message
             let _msg = rx.recv().await;
 
             // Now we should be able to send
-            let result2 = tx.try_send(KeyboardCommand::TypeText("3".to_string(), cancellation_flag));
+            let result2 = tx.try_send(KeyboardCommand::TypeText(
+                "3".to_string(),
+                cancellation_flag,
+            ));
             assert!(result2.is_ok());
         });
     }

--- a/src-tauri/src/keyboard_mock_tests.rs
+++ b/src-tauri/src/keyboard_mock_tests.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod keyboard_mock_tests {
+    use std::sync::{atomic::AtomicBool, Arc};
+
     use tokio::sync::mpsc;
 
     use crate::keyboard::{KeyboardCommand, TypingSpeed};
@@ -10,7 +12,10 @@ mod keyboard_mock_tests {
         let (tx, mut rx) = mpsc::channel::<KeyboardCommand>(1);
 
         // Fill the channel
-        let _ = tx.try_send(KeyboardCommand::TypeText("test".to_string()));
+        let _ = tx.try_send(KeyboardCommand::TypeText(
+            "test".to_string(),
+            Arc::new(AtomicBool::new(false)),
+        ));
 
         // Try to send when full
         let result = tx.try_send(KeyboardCommand::SetSpeed(TypingSpeed::Fast));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod app_logic;
 mod clipboard;
 pub mod config;
 mod helpers;
+mod hotkey;
 pub mod keyboard;
 mod tray;
 
@@ -63,21 +64,43 @@ mod clipboard_platform_tests;
 mod integration_tests;
 
 #[cfg(test)]
+mod integration_test_emergency_stop;
+
+#[cfg(test)]
 mod app_logic_comprehensive_tests;
 
 #[cfg(test)]
 mod mock_keyboard;
 
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 use log::{error, info};
 use tauri::{Listener, Manager, State};
 
-use crate::{config::ConfigManager, keyboard::KeyboardEmulator, tray::TrayManager};
+use crate::{config::ConfigManager, hotkey::HotkeyManager, keyboard::KeyboardEmulator, tray::TrayManager};
 
 #[derive(Clone)]
 pub struct AppState {
     keyboard_emulator: Arc<KeyboardEmulator>,
+    is_typing_cancelled: Arc<AtomicBool>,
+}
+
+impl AppState {
+    pub fn cancel_typing(&self) {
+        self.is_typing_cancelled.store(true, Ordering::Relaxed);
+        info!("Typing operation cancelled by user");
+    }
+
+    pub fn reset_cancellation(&self) {
+        self.is_typing_cancelled.store(false, Ordering::Relaxed);
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.is_typing_cancelled.load(Ordering::Relaxed)
+    }
 }
 
 /// Initialize app components and return them for testing
@@ -102,7 +125,10 @@ pub fn initialize_components(
 
 /// Create app state from components
 pub fn create_app_state(keyboard_emulator: Arc<KeyboardEmulator>) -> AppState {
-    AppState { keyboard_emulator }
+    AppState {
+        keyboard_emulator,
+        is_typing_cancelled: Arc::new(AtomicBool::new(false)),
+    }
 }
 
 /// Setup event handlers for the app
@@ -116,17 +142,20 @@ pub fn handle_config_changed(
 }
 
 /// Handle paste clipboard event in a new thread
-pub fn handle_paste_clipboard_event(keyboard_emulator: Arc<KeyboardEmulator>) {
+pub fn handle_paste_clipboard_event(keyboard_emulator: Arc<KeyboardEmulator>, cancellation_flag: Arc<AtomicBool>) {
     use app_logic::{handle_paste_clipboard, SystemClipboard};
 
     info!("{}", helpers::format_paste_event_log());
+
+    // Reset the cancellation flag before starting
+    cancellation_flag.store(false, Ordering::Relaxed);
 
     let clipboard = SystemClipboard;
 
     std::thread::spawn(move || {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async move {
-            if let Err(e) = handle_paste_clipboard(&clipboard, &keyboard_emulator).await {
+            if let Err(e) = handle_paste_clipboard(&clipboard, &keyboard_emulator, cancellation_flag).await {
                 error!("{}", helpers::format_paste_error(&e.to_string()));
             }
         });
@@ -138,6 +167,7 @@ pub fn setup_event_handlers<R: tauri::Runtime>(
     app_handle: &tauri::AppHandle<R>,
     config_manager: Arc<ConfigManager>,
     keyboard_emulator: Arc<KeyboardEmulator>,
+    cancellation_flag: Arc<AtomicBool>,
 ) {
     // Listen for config changes
     let keyboard_emulator_clone = keyboard_emulator.clone();
@@ -150,9 +180,17 @@ pub fn setup_event_handlers<R: tauri::Runtime>(
 
     // Handle paste clipboard event from tray
     let keyboard_emulator_clone = keyboard_emulator;
+    let cancellation_flag_clone = cancellation_flag.clone();
     let (_, paste_event) = helpers::get_event_names();
     app_handle.listen(paste_event, move |_event| {
-        handle_paste_clipboard_event(keyboard_emulator_clone.clone());
+        handle_paste_clipboard_event(keyboard_emulator_clone.clone(), cancellation_flag_clone.clone());
+    });
+
+    // Handle cancel typing event from tray
+    let cancellation_flag_clone = cancellation_flag;
+    app_handle.listen("cancel_typing", move |_event| {
+        info!("Cancel typing event received");
+        cancellation_flag_clone.store(true, Ordering::Relaxed);
     });
 }
 
@@ -160,8 +198,17 @@ pub fn setup_event_handlers<R: tauri::Runtime>(
 async fn paste_clipboard(state: State<'_, AppState>) -> Result<(), String> {
     use app_logic::{handle_paste_clipboard, SystemClipboard};
 
+    // Reset the cancellation flag before starting
+    state.reset_cancellation();
+
     let clipboard = SystemClipboard;
-    handle_paste_clipboard(&clipboard, &state.keyboard_emulator).await
+    handle_paste_clipboard(&clipboard, &state.keyboard_emulator, state.is_typing_cancelled.clone()).await
+}
+
+#[tauri::command]
+async fn cancel_typing(state: State<'_, AppState>) -> Result<(), String> {
+    state.cancel_typing();
+    Ok(())
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -171,6 +218,7 @@ pub fn run() {
     helpers::log_initialization();
 
     tauri::Builder::default()
+        .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .setup(|app| {
             // Hide dock icon on startup (macOS)
             #[cfg(target_os = "macos")]
@@ -193,14 +241,19 @@ pub fn run() {
 
             // Create app state
             let app_state = create_app_state(keyboard_emulator.clone());
+            let cancellation_flag = app_state.is_typing_cancelled.clone();
             app.manage(app_state);
 
             // Setup event handlers
-            setup_event_handlers(app.handle(), config_manager, keyboard_emulator);
+            setup_event_handlers(app.handle(), config_manager, keyboard_emulator, cancellation_flag.clone());
+
+            // Setup global hotkeys
+            let hotkey_manager = HotkeyManager::new();
+            hotkey_manager.register_hotkeys(app.handle(), cancellation_flag)?;
 
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![paste_clipboard])
+        .invoke_handler(tauri::generate_handler![paste_clipboard, cancel_typing])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
@@ -232,7 +285,10 @@ mod tests {
 
             let keyboard_emulator = Arc::new(KeyboardEmulator::new().unwrap());
 
-            let app_state = AppState { keyboard_emulator };
+            let app_state = AppState {
+                keyboard_emulator,
+                is_typing_cancelled: Arc::new(AtomicBool::new(false)),
+            };
 
             Self { app_state }
         }
@@ -246,10 +302,11 @@ mod tests {
         let mock_state = MockState::new();
 
         // Test that keyboard emulator can receive type_text commands
+        let cancellation_flag = Arc::new(AtomicBool::new(false));
         let result = mock_state
             .app_state
             .keyboard_emulator
-            .type_text("test")
+            .type_text("test", cancellation_flag)
             .await;
         assert!(result.is_ok());
     }
@@ -264,10 +321,11 @@ mod tests {
         // We can't directly test paste_clipboard because it uses get_clipboard_content
         // which requires system clipboard access, but we can test the keyboard emulator
         let test_text = "Hello, World!";
+        let cancellation_flag = Arc::new(AtomicBool::new(false));
         let result = mock_state
             .app_state
             .keyboard_emulator
-            .type_text(test_text)
+            .type_text(test_text, cancellation_flag)
             .await;
         assert!(result.is_ok());
     }
@@ -281,10 +339,11 @@ mod tests {
 
         // Test with very long text that might cause issues
         let long_text = "a".repeat(10000);
+        let cancellation_flag = Arc::new(AtomicBool::new(false));
         let result = mock_state
             .app_state
             .keyboard_emulator
-            .type_text(&long_text)
+            .type_text(&long_text, cancellation_flag)
             .await;
         assert!(result.is_ok()); // Should handle long text gracefully
     }
@@ -306,6 +365,7 @@ mod tests {
 
         let app_state = AppState {
             keyboard_emulator: keyboard_emulator.clone(),
+            is_typing_cancelled: Arc::new(AtomicBool::new(false)),
         };
 
         // Test cloning
@@ -380,10 +440,31 @@ mod tests {
 
         let _app_state = AppState {
             keyboard_emulator: keyboard_emulator.clone(),
+            is_typing_cancelled: Arc::new(AtomicBool::new(false)),
         };
 
         // Verify app state holds correct reference to keyboard emulator
         // (config is no longer part of app state)
+    }
+
+    #[test]
+    fn test_app_state_cancellation_methods() {
+        let keyboard_emulator = Arc::new(KeyboardEmulator::new().unwrap());
+        let app_state = AppState {
+            keyboard_emulator,
+            is_typing_cancelled: Arc::new(AtomicBool::new(false)),
+        };
+
+        // Test initial state
+        assert!(!app_state.is_cancelled());
+
+        // Test cancel_typing
+        app_state.cancel_typing();
+        assert!(app_state.is_cancelled());
+
+        // Test reset_cancellation
+        app_state.reset_cancellation();
+        assert!(!app_state.is_cancelled());
     }
 
     #[test]
@@ -518,6 +599,7 @@ mod tests {
         // Step 5: App state needs both config and keyboard
         let app_state = AppState {
             keyboard_emulator: keyboard_emulator.clone(),
+            is_typing_cancelled: Arc::new(AtomicBool::new(false)),
         };
 
         // Verify everything is connected properly
@@ -698,9 +780,10 @@ mod tests {
     #[cfg(not(tarpaulin))]
     fn test_handle_paste_clipboard_event() {
         let keyboard_emulator = Arc::new(KeyboardEmulator::new().unwrap());
+        let cancellation_flag = Arc::new(AtomicBool::new(false));
 
         // Call the function - it spawns a thread
-        handle_paste_clipboard_event(keyboard_emulator.clone());
+        handle_paste_clipboard_event(keyboard_emulator.clone(), cancellation_flag);
 
         // Give the spawned thread time to start
         std::thread::sleep(std::time::Duration::from_millis(10));

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod lib_coverage_tests {
-    use std::sync::{Arc, Mutex};
+    use std::sync::{atomic::AtomicBool, Arc, Mutex};
 
     use tempfile::TempDir;
 
@@ -76,7 +76,10 @@ mod lib_coverage_tests {
 
         // Call handle_paste_clipboard_event multiple times
         for _ in 0..3 {
-            handle_paste_clipboard_event(keyboard_emulator.clone());
+            handle_paste_clipboard_event(
+                keyboard_emulator.clone(),
+                Arc::new(AtomicBool::new(false)),
+            );
         }
 
         // Give threads time to start
@@ -167,7 +170,7 @@ mod lib_coverage_tests {
         for _ in 0..5 {
             let ke = keyboard_emulator.clone();
             let handle = std::thread::spawn(move || {
-                handle_paste_clipboard_event(ke);
+                handle_paste_clipboard_event(ke, Arc::new(AtomicBool::new(false)));
             });
             handles.push(handle);
         }

--- a/src-tauri/src/mock_keyboard.rs
+++ b/src-tauri/src/mock_keyboard.rs
@@ -1,7 +1,9 @@
 #[cfg(test)]
 pub mod mock {
-    use std::sync::{Arc, Mutex};
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    };
 
     use tokio::sync::mpsc;
 
@@ -56,9 +58,16 @@ pub mod mock {
             let _ = self.tx.try_send(KeyboardCommand::SetSpeed(speed));
         }
 
-        pub async fn type_text(&self, text: &str, cancellation_flag: Arc<AtomicBool>) -> Result<(), Box<dyn std::error::Error>> {
+        pub async fn type_text(
+            &self,
+            text: &str,
+            cancellation_flag: Arc<AtomicBool>,
+        ) -> Result<(), Box<dyn std::error::Error>> {
             self.tx
-                .send(KeyboardCommand::TypeText(text.to_string(), cancellation_flag))
+                .send(KeyboardCommand::TypeText(
+                    text.to_string(),
+                    cancellation_flag,
+                ))
                 .await?;
             Ok(())
         }

--- a/src-tauri/src/runtime_mock_tests.rs
+++ b/src-tauri/src/runtime_mock_tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod runtime_mock_tests {
     use std::{
-        sync::{Arc, Mutex},
+        sync::{atomic::AtomicBool, Arc, Mutex},
         time::Duration,
     };
 
@@ -21,7 +21,7 @@ mod runtime_mock_tests {
         let initial_count = Arc::strong_count(&keyboard_emulator);
 
         // Call the function which spawns a thread
-        handle_paste_clipboard_event(keyboard_emulator.clone());
+        handle_paste_clipboard_event(keyboard_emulator.clone(), Arc::new(AtomicBool::new(false)));
 
         // Give the thread time to start and grab the Arc
         std::thread::sleep(Duration::from_millis(10));
@@ -41,7 +41,10 @@ mod runtime_mock_tests {
 
         // Spawn multiple paste events
         for _ in 0..5 {
-            handle_paste_clipboard_event(keyboard_emulator.clone());
+            handle_paste_clipboard_event(
+                keyboard_emulator.clone(),
+                Arc::new(AtomicBool::new(false)),
+            );
         }
 
         // Give threads time to start
@@ -60,7 +63,10 @@ mod runtime_mock_tests {
 
         for speed in speeds {
             keyboard_emulator.set_typing_speed(speed);
-            handle_paste_clipboard_event(keyboard_emulator.clone());
+            handle_paste_clipboard_event(
+                keyboard_emulator.clone(),
+                Arc::new(AtomicBool::new(false)),
+            );
             std::thread::sleep(Duration::from_millis(20));
         }
 
@@ -143,7 +149,7 @@ mod runtime_mock_tests {
         let initial_count = Arc::strong_count(&keyboard_emulator);
 
         // Trigger paste event
-        handle_paste_clipboard_event(keyboard_emulator.clone());
+        handle_paste_clipboard_event(keyboard_emulator.clone(), Arc::new(AtomicBool::new(false)));
 
         // Wait for thread to complete
         std::thread::sleep(Duration::from_millis(150));

--- a/src-tauri/src/tauri_mock_tests.rs
+++ b/src-tauri/src/tauri_mock_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tauri_mock_tests {
-    use std::sync::{Arc, Mutex};
+    use std::sync::{atomic::AtomicBool, Arc, Mutex};
 
     use tempfile::TempDir;
 
@@ -86,7 +86,7 @@ mod tauri_mock_tests {
         let initial_count = Arc::strong_count(&keyboard_emulator);
 
         // Handle paste event (spawns a thread)
-        handle_paste_clipboard_event(keyboard_emulator.clone());
+        handle_paste_clipboard_event(keyboard_emulator.clone(), Arc::new(AtomicBool::new(false)));
 
         // Give thread time to spawn
         std::thread::sleep(std::time::Duration::from_millis(50));
@@ -105,6 +105,7 @@ mod tauri_mock_tests {
         let keyboard_emulator = Arc::new(KeyboardEmulator::new().unwrap());
         let app_state = AppState {
             keyboard_emulator: keyboard_emulator.clone(),
+            is_typing_cancelled: Arc::new(AtomicBool::new(false)),
         };
 
         // Verify the state contains the keyboard emulator
@@ -205,7 +206,10 @@ mod tauri_mock_tests {
 
         // Trigger multiple paste events
         for _ in 0..5 {
-            handle_paste_clipboard_event(keyboard_emulator.clone());
+            handle_paste_clipboard_event(
+                keyboard_emulator.clone(),
+                Arc::new(AtomicBool::new(false)),
+            );
         }
 
         // Give threads time to spawn

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -132,6 +132,10 @@ impl TrayManager {
                             info!("Paste menu item clicked");
                             app.emit("paste_clipboard", ()).unwrap();
                         }
+                        MenuAction::CancelTyping => {
+                            info!("Cancel typing menu item clicked");
+                            app.emit("cancel_typing", ()).unwrap();
+                        }
                         MenuAction::SetTypingSpeed(speed) => {
                             config_manager.set_typing_speed(speed);
 

--- a/src-tauri/src/tray_builder_tests.rs
+++ b/src-tauri/src/tray_builder_tests.rs
@@ -52,7 +52,7 @@ mod tray_builder_tests {
             }
         }
 
-        assert_eq!(action_count, 2); // Paste, Quit
+        assert_eq!(action_count, 3); // Paste, Cancel Typing, Quit
         assert_eq!(check_count, 1); // Left Click Pastes
         assert_eq!(submenu_count, 1); // Typing Speed
         assert_eq!(separator_count, 2); // Two separators

--- a/src-tauri/tests/integration_test.rs
+++ b/src-tauri/tests/integration_test.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{atomic::AtomicBool, Arc};
 
 use pasta_tray_lib::{
     config::{Config, ConfigManager},
@@ -59,14 +59,20 @@ async fn test_keyboard_emulator_async_operations() {
     let keyboard_emulator = KeyboardEmulator::new().unwrap();
 
     // Test multiple async operations
-    let result1 = keyboard_emulator.type_text("Hello").await;
+    let result1 = keyboard_emulator
+        .type_text("Hello", Arc::new(AtomicBool::new(false)))
+        .await;
     assert!(result1.is_ok());
 
-    let result2 = keyboard_emulator.type_text("World").await;
+    let result2 = keyboard_emulator
+        .type_text("World", Arc::new(AtomicBool::new(false)))
+        .await;
     assert!(result2.is_ok());
 
     // Test with special characters
-    let result3 = keyboard_emulator.type_text("Line1\nLine2\tTabbed").await;
+    let result3 = keyboard_emulator
+        .type_text("Line1\nLine2\tTabbed", Arc::new(AtomicBool::new(false)))
+        .await;
     assert!(result3.is_ok());
 }
 
@@ -152,7 +158,9 @@ async fn test_keyboard_emulator_channel_capacity() {
     // Send multiple commands quickly
     let mut results = vec![];
     for i in 0..5 {
-        let result = keyboard_emulator.type_text(&format!("Text {}", i)).await;
+        let result = keyboard_emulator
+            .type_text(&format!("Text {}", i), Arc::new(AtomicBool::new(false)))
+            .await;
         results.push(result);
     }
 


### PR DESCRIPTION
- Add thread-safe cancellation flag to AppState
- Implement double-Escape detection (500ms window) using tauri-plugin-global-shortcut
- Update keyboard emulator to check cancellation flag during typing
- Add 'Cancel Typing (Esc Esc)' menu item to system tray
- Check cancellation at chunk boundaries and every 10 characters
- Add comprehensive unit and integration tests for cancellation
- Update documentation in README and CLAUDE.md